### PR TITLE
remove sceneServices check in Portal Login Page

### DIFF
--- a/Portal/PortalSettingsPage.qml
+++ b/Portal/PortalSettingsPage.qml
@@ -459,16 +459,12 @@ Rectangle {
                                 if (readyState === NetworkRequest.ReadyStateComplete)
                                 {
                                     if (status === 200) {
-
                                         console.log("self:", JSON.stringify(response, undefined, 2));
-
-                                        if (response.isPortal && !response.supportsHostedServices) {
-                                            addPortalError.text = qsTr("Tile Package Kreator requires that Portal for ArcGIS 10.3.1 or later and is configured with a Hosted Server and ArcGIS Data Store");
-                                        } else {
+                                        if (response.isPortal) {
                                             portalVersionRequest.send();
                                             infoRequest.send();
                                         }
-                                    }
+                                     }
                                 }
                             }
 

--- a/Portal/PortalSettingsPage.qml
+++ b/Portal/PortalSettingsPage.qml
@@ -462,7 +462,7 @@ Rectangle {
 
                                         console.log("self:", JSON.stringify(response, undefined, 2));
 
-                                        if (response.isPortal && !(response.supportsHostedServices && response.supportsSceneServices)) {
+                                        if (response.isPortal && !response.supportsHostedServices) {
                                             addPortalError.text = qsTr("Tile Package Kreator requires that Portal for ArcGIS 10.3.1 or later and is configured with a Hosted Server and ArcGIS Data Store");
                                         } else {
                                             portalVersionRequest.send();


### PR DESCRIPTION
Currently Tile Package Kreator fails to login to a Portal that does not have a tilecache data store configured. This is not necessary for Tile Package Kreator to run so I am suggesting that we remove that check. 